### PR TITLE
Update BankingSicoob.php

### DIFF
--- a/src/BankingSicoob.php
+++ b/src/BankingSicoob.php
@@ -30,7 +30,8 @@ class BankingSicoob{
             'headers' => [
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json',
-                'x-sicoob-clientid' => $config['client_id']
+                'x-sicoob-clientid' => $config['client_id'],
+                'client_id' => $config['client_id']
             ],
             'cert' => $config['certificate'], 
             // 'verify' => false,


### PR DESCRIPTION
aparti de 30/07/2023 é obrigatório enviar o client_id em todas as requisições segue mensagem abaixo enviada pelo banco

"Com o objetivo de aprimorar nosso ecossistema e solucionar problemas relacionados às APIs, realizamos uma modificação em nosso ambiente. Essa alteração permitirá que possamos realizar investigações mais detalhadas das requisições das APIs. Como resultado, solicitamos que o elemento "client_id" seja incluído no cabeçalho (header) de todas as requisições de consumo. Por outro lado, o valor informado no {{client_id}} deve ser o mesmo que estava sendo utilizado anteriormente.

Além disso, é necessário destacar que o parâmetro “client_id” não deverá ser alterado na requisição de autenticação (Token), uma vez que ele se encontra no corpo (Body) e já está preenchido corretamente. Portanto, a ação ocorrerá apenas nas requisições de consumo das APIs."